### PR TITLE
Fix the gitignore syntax to exclude bin and obj folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.csproj.user
 *.suo
-*/bin/*
-*/obj/*
+bin/
+obj/
 *.Cache
 *_ReSharper.uComponents*
 DLLs/*


### PR DESCRIPTION
I think this syntax may have been leftover from the old `hgignore`
