### PR TITLE
Fix Nuget package restore // build issues

### DIFF
--- a/src/.nuget/NuGet.targets
+++ b/src/.nuget/NuGet.targets
@@ -10,7 +10,7 @@
         <BuildPackage Condition=" '$(BuildPackage)' == '' ">false</BuildPackage>
 
         <!-- Determines if package restore consent is required to restore packages -->
-        <RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'false' ">true</RequireRestoreConsent>
+        <RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'true' ">false</RequireRestoreConsent>
         
         <!-- Download NuGet.exe if it does not already exist -->
         <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">false</DownloadNuGetExe>


### PR DESCRIPTION
Not exactly sure why this is needed, but we do it on all of our projects to avoid the "you must give consent" errors during builds.
