### PR TITLE
Changed the TextStringArray PropertyEditorValueConverter to use the correct DataType constant

### DIFF
--- a/src/uComponents.PropertyEditors.ValueConverters/TextstringArray/TextstringArrayPropertyEditorValueConverter.cs
+++ b/src/uComponents.PropertyEditors.ValueConverters/TextstringArray/TextstringArrayPropertyEditorValueConverter.cs
@@ -21,7 +21,7 @@ namespace uComponents.DataTypes.RazorDataTypeModels.TextstringArray
 		/// <returns></returns>
 		public bool IsConverterFor(Guid propertyEditorId, string docTypeAlias, string propertyTypeAlias)
 		{
-			return Guid.Parse(DataTypeConstants.CheckBoxTreeId).Equals(propertyEditorId);
+			return Guid.Parse(DataTypeConstants.TextstringArrayId).Equals(propertyEditorId);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This commit fixes #20.

The DataType constant used by the TextStringArray PropertyEditorValueconverter has been changed to the correct constant. It was using CheckBoxTreeId rather than TextStringArrayId.
