### PR TITLE
Fix type error ('c.replace is not a function').

### DIFF
--- a/src/uComponents.DataTypes/UrlPicker/UrlPickerScripts.js
+++ b/src/uComponents.DataTypes/UrlPicker/UrlPickerScripts.js
@@ -371,7 +371,7 @@ Date modified: 15th of March, 2011
                 url: settings.AjaxUploadHandlerUrl + "?" + settings.AjaxUploadHandlerGuid + "_Id=" + settings.UniquePropertyId,
                 success: function (responseText) {
                     // Strip any <pre> tags and parse the JSON
-                    var response = jQuery.parseJSON(responseText.replace(/<(\/)?pre[^>]*>/gi, ""));
+                    var response = typeof responseText === "string" ? jQuery.parseJSON(responseText.replace(/<(\/)?pre[^>]*>/gi, "")) : responseText;
 
                     // Check for errors, if there are none do a report on files saved
                     if (response.statusCode !== 200) {


### PR DESCRIPTION
I got an exception during upload via multi url picker, caused by an changed parameter type. Maybe this comes from a newer jQuery version in the current Umbraco 6.2.5.