### PR TITLE
fix: #30

### DIFF
--- a/src/uComponents.DataTypes/UrlPicker/Services/UrlPickerService.cs
+++ b/src/uComponents.DataTypes/UrlPicker/Services/UrlPickerService.cs
@@ -41,7 +41,7 @@ namespace uComponents.DataTypes.UrlPicker.Services
         {
             Authorize();
 
-            var media = XElement.Parse(library.GetMedia((int)id, false).Current.InnerXml);
+            var media = XElement.Parse(library.GetMedia((int)id, false).Current.OuterXml);
 
             var umbracoFile = media.Element(Constants.Umbraco.Media.File);
 


### PR DESCRIPTION
uComponents URL picker not working after Umbraco 6.2.4 to 6.2.5 upgrade.
issue #30 
I have also tested version 6.1.3 and OuterXml instead of InnerXml is alos fine for this version.